### PR TITLE
spellchecker: include Czech

### DIFF
--- a/java/res/xml/spellchecker.xml
+++ b/java/res/xml/spellchecker.xml
@@ -59,4 +59,8 @@
             android:label="@string/subtype_generic"
             android:subtypeLocale="pt_BR"
     />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="cs"
+    />
 </spell-checker>


### PR DESCRIPTION
Hi!
I've just installed GrapheneOS for the first time and I am missing spellcheck / suggestions when the Czech language is selected. 
This should fix that, since there is the Czech dictionary already there in the repo as well as other `cs`y things. 
I have not tested this since I probably don't have enough space on my machine right now to do the whole AOSP tree build (I believe that's necessary?), but it should be a small enough change.

Please have a look and let me know if there is something else needed to be done. Thank you!