### PR TITLE
remove launcher icon

### DIFF
--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -106,7 +106,6 @@
              android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
It's already removed automatically by disabling this activity (SetupActivity) from within LatinIME itself, but that leads to launcher icon briefly showing up in new users/profiles.