### PR TITLE
Add existing wordlist in spellchecker.xml

### DIFF
--- a/java/res/xml/spellchecker.xml
+++ b/java/res/xml/spellchecker.xml
@@ -67,4 +67,56 @@
             android:label="@string/subtype_generic"
             android:subtypeLocale="cs"
     />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="da"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="el"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="fi"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="iw"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="lt"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="lv"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="nb"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="pl"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="ro"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="sl"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="sr"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="sv"
+    />
+    <subtype
+            android:label="@string/subtype_generic"
+            android:subtypeLocale="tr"
+    />
 </spell-checker>


### PR DESCRIPTION
I don't quite understand why not all wordlist have been entered in the spellchecker.xml file. Is there a reason for this?