### PR TITLE
secure paste: add Paste actions to LatinIME

### DIFF
--- a/common/src/com/android/inputmethod/latin/common/Constants.java
+++ b/common/src/com/android/inputmethod/latin/common/Constants.java
@@ -69,6 +69,11 @@ public final class Constants {
          */
         public static final String NO_FLOATING_GESTURE_PREVIEW = "noGestureFloatingPreview";
 
+        /**
+         * The private IME option used to suppress clipboard paste actions for a given text field.
+         */
+        public static final String NO_CLIPBOARD_PASTE = "noClipboardPaste";
+
         private ImeOption() {
             // This utility class is not publicly instantiable.
         }

--- a/java/res/drawable/btn_paste_holo.xml
+++ b/java/res/drawable/btn_paste_holo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2026 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="#40FFFFFF" />
+            <corners android:radius="@dimen/config_paste_button_corner_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#26FFFFFF" />
+            <corners android:radius="@dimen/config_paste_button_corner_radius" />
+        </shape>
+    </item>
+</selector>

--- a/java/res/drawable/btn_paste_lxx_light.xml
+++ b/java/res/drawable/btn_paste_lxx_light.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2026 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="#4037474F" />
+            <corners android:radius="@dimen/config_paste_button_corner_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@color/suggested_word_background_selected_lxx_light" />
+            <corners android:radius="@dimen/config_paste_button_corner_radius" />
+        </shape>
+    </item>
+</selector>

--- a/java/res/drawable/ic_clipboard_action.xml
+++ b/java/res/drawable/ic_clipboard_action.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2014 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,2l-4.2,0c-0.4,-1.2 -1.5,-2 -2.8,-2c-1.3,0 -2.4,0.8 -2.8,2L5,2C3.9,2 3,2.9 3,4l0,16c0,1.1 0.9,2 2,2l14,0c1.1,0 2,-0.9 2,-2L21,4C21,2.9 20.1,2 19,2zM12,2c0.6,0 1,0.4 1,1s-0.4,1 -1,1c-0.6,0 -1,-0.4 -1,-1S11.4,2 12,2zM19,20L5,20L5,4l2,0l0,3l10,0L17,4l2,0L19,20z" />
+</vector>

--- a/java/res/drawable/ic_clipboard_paste.xml
+++ b/java/res/drawable/ic_clipboard_paste.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2023 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/config_paste_button_icon_size"
+    android:height="@dimen/config_paste_button_icon_size"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,42Q7.7,42 6.85,41.15Q6,40.3 6,39V9Q6,7.7 6.85,6.85Q7.7,6 9,6H19.1Q19.45,4.25 20.825,3.125Q22.2,2 24,2Q25.8,2 27.175,3.125Q28.55,4.25 28.9,6H39Q40.3,6 41.15,6.85Q42,7.7 42,9V39Q42,40.3 41.15,41.15Q40.3,42 39,42ZM9,39H39Q39,39 39,39Q39,39 39,39V9Q39,9 39,9Q39,9 39,9H36V13.5H12V9H9Q9,9 9,9Q9,9 9,9V39Q9,39 9,39Q9,39 9,39ZM24,9Q24.85,9 25.425,8.425Q26,7.85 26,7Q26,6.15 25.425,5.575Q24.85,5 24,5Q23.15,5 22.575,5.575Q22,6.15 22,7Q22,7.85 22.575,8.425Q23.15,9 24,9Z" />
+</vector>

--- a/java/res/drawable/ic_close_paste_mode.xml
+++ b/java/res/drawable/ic_close_paste_mode.xml
@@ -1,0 +1,24 @@
+<!--
+Copyright (C) 2016 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18.3,5.71a0.996,0.996 0,0 0,-1.41 0L12,10.59 7.11,5.7A0.996,0.996 0,1 0,5.7 7.11L10.59,12 5.7,16.89a0.996,0.996 0,1 0,1.41 1.41L12,13.41l4.89,4.89a0.996,0.996 0,1 0,1.41 -1.41L13.41,12l4.89,-4.89c0.38,-0.38 0.38,-1.02 0,-1.4z" />
+</vector>

--- a/java/res/layout/suggestions_strip.xml
+++ b/java/res/layout/suggestions_strip.xml
@@ -52,6 +52,55 @@
             android:textSize="16sp"
             style="?attr/suggestionWordStyle" />
     </LinearLayout>
+    <HorizontalScrollView
+        android:id="@+id/paste_actions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/config_suggestions_strip_edge_key_width"
+        android:layout_marginEnd="@dimen/config_suggestions_strip_edge_key_width"
+        android:layout_centerVertical="true"
+        android:fillViewport="true"
+        android:overScrollMode="never"
+        android:scrollbars="none">
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal">
+            <LinearLayout
+                android:id="@+id/paste_button"
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/config_paste_button_height"
+                android:contentDescription="@android:string/paste"
+                android:orientation="horizontal"
+                style="?attr/pasteButtonStyle">
+                <ImageView
+                    android:id="@+id/paste_button_icon"
+                    android:layout_width="@dimen/config_paste_button_icon_size"
+                    android:layout_height="@dimen/config_paste_button_icon_size"
+                    android:layout_marginEnd="@dimen/config_paste_button_drawable_padding"
+                    android:duplicateParentState="true"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_clipboard_paste" />
+                <TextView
+                    android:id="@+id/paste_button_text"
+                    android:text="@android:string/paste"
+                    style="?attr/pasteButtonTextStyle" />
+            </LinearLayout>
+        </LinearLayout>
+    </HorizontalScrollView>
+    <ImageButton
+        android:id="@+id/suggestions_strip_paste_key"
+        android:layout_width="@dimen/config_suggestions_strip_edge_key_width"
+        android:layout_height="fill_parent"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:contentDescription="@string/spoken_description_show_paste_button"
+        android:scaleType="centerInside"
+        android:src="@drawable/ic_clipboard_action"
+        android:visibility="invisible"
+        style="?attr/suggestionWordStyle" />
     <ImageButton
         android:id="@+id/suggestions_strip_voice_key"
         android:layout_width="@dimen/config_suggestions_strip_edge_key_width"

--- a/java/res/values-sw600dp/config.xml
+++ b/java/res/values-sw600dp/config.xml
@@ -71,6 +71,7 @@
     <fraction name="config_min_more_suggestions_width">90%</fraction>
     <dimen name="config_suggestion_min_width">48.0dp</dimen>
     <dimen name="config_suggestion_text_horizontal_padding">10dp</dimen>
+    <dimen name="config_paste_button_icon_size">22dp</dimen>
     <dimen name="config_suggestion_text_size">22dp</dimen>
     <dimen name="config_more_suggestions_hint_text_size">33dp</dimen>
 

--- a/java/res/values/attrs.xml
+++ b/java/res/values/attrs.xml
@@ -40,6 +40,10 @@
         <attr name="suggestionStripViewStyle" format="reference" />
         <!-- Suggestion word style -->
         <attr name="suggestionWordStyle" format="reference" />
+        <!-- Paste button style -->
+        <attr name="pasteButtonStyle" format="reference" />
+        <!-- Paste button text style -->
+        <attr name="pasteButtonTextStyle" format="reference" />
     </declare-styleable>
 
     <declare-styleable name="KeyboardView">

--- a/java/res/values/config.xml
+++ b/java/res/values/config.xml
@@ -76,6 +76,12 @@
     <fraction name="config_min_more_suggestions_width">90%</fraction>
     <dimen name="config_suggestion_min_width">44dp</dimen>
     <dimen name="config_suggestion_text_horizontal_padding">6dp</dimen>
+    <dimen name="config_paste_button_height">28dp</dimen>
+    <dimen name="config_paste_button_horizontal_padding">12dp</dimen>
+    <dimen name="config_paste_button_drawable_padding">8dp</dimen>
+    <dimen name="config_paste_button_icon_size">18dp</dimen>
+    <dimen name="config_paste_button_corner_radius">14dp</dimen>
+    <bool name="config_default_show_paste_button">true</bool>
     <dimen name="config_suggestion_text_size">18dp</dimen>
     <dimen name="config_more_suggestions_hint_text_size">27dp</dimen>
 

--- a/java/res/values/strings-talkback-descriptions.xml
+++ b/java/res/values/strings-talkback-descriptions.xml
@@ -62,6 +62,10 @@
     <string name="spoken_description_space">Space</string>
     <!-- Spoken description for the "Mic" keyboard key. -->
     <string name="spoken_description_mic">Voice input</string>
+    <!-- Spoken description for the button that temporarily replaces suggestions with Paste. -->
+    <string name="spoken_description_show_paste_button">Show paste button</string>
+    <!-- Spoken description for the button that closes the temporary Paste mode. -->
+    <string name="spoken_description_show_suggestions">Show suggestions</string>
     <!-- Spoken description for the "Emoji" keyboard key. -->
     <string name="spoken_description_emoji">Emoji</string>
     <!-- Spoken description for the "Return" keyboard key. -->

--- a/java/res/values/strings.xml
+++ b/java/res/values/strings.xml
@@ -142,6 +142,11 @@
     <!-- Description for show suggestions -->
     <string name="prefs_show_suggestions_summary">Display suggested words while typing</string>
 
+    <!-- Option to show the paste button in the suggestion strip [CHAR LIMIT=30] -->
+    <string name="prefs_show_paste_button">Show paste button</string>
+    <!-- Description for the option to show the paste button [CHAR LIMIT=65] -->
+    <string name="prefs_show_paste_button_summary">Show a button for copied text, images, and other content</string>
+
     <!-- Option to block potentially offensive words to be shown [CHAR_LIMIT=30] -->
     <string name="prefs_block_potentially_offensive_title">Block offensive words</string>
     <!-- Summary for option to block potentially offensive words to be shown [CHAR_LIMIT=80 (two lines) or 40 (fits on one line, preferable)] -->

--- a/java/res/values/themes-common.xml
+++ b/java/res/values/themes-common.xml
@@ -130,4 +130,24 @@
         <item name="android:singleLine">true</item>
         <item name="android:ellipsize">none</item>
     </style>
+    <style name="PasteButton">
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:baselineAligned">false</item>
+        <item name="android:paddingStart">@dimen/config_paste_button_horizontal_padding</item>
+        <item name="android:paddingEnd">@dimen/config_paste_button_horizontal_padding</item>
+        <item name="android:hapticFeedbackEnabled">false</item>
+        <item name="android:soundEffectsEnabled">false</item>
+        <item name="android:focusable">false</item>
+        <item name="android:clickable">true</item>
+    </style>
+    <style name="PasteButtonText">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:textSize">@dimen/config_suggestion_text_size</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:duplicateParentState">true</item>
+        <item name="android:importantForAccessibility">no</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:ellipsize">none</item>
+    </style>
 </resources>

--- a/java/res/values/themes-ics.xml
+++ b/java/res/values/themes-ics.xml
@@ -31,6 +31,8 @@
         <item name="moreKeysKeyboardViewForActionStyle">@style/MoreKeysKeyboardView.ICS</item>
         <item name="suggestionStripViewStyle">@style/SuggestionStripView.ICS</item>
         <item name="suggestionWordStyle">@style/SuggestionWord.ICS</item>
+        <item name="pasteButtonStyle">@style/PasteButton.ICS</item>
+        <item name="pasteButtonTextStyle">@style/PasteButtonText.ICS</item>
     </style>
     <style
         name="Keyboard.ICS"
@@ -145,6 +147,18 @@
         parent="SuggestionWord"
     >
         <item name="android:background">@drawable/btn_suggestion_ics</item>
+        <item name="android:textColor">@color/highlight_color_ics</item>
+    </style>
+    <style
+        name="PasteButton.ICS"
+        parent="PasteButton"
+    >
+        <item name="android:background">@drawable/btn_paste_holo</item>
+    </style>
+    <style
+        name="PasteButtonText.ICS"
+        parent="PasteButtonText"
+    >
         <item name="android:textColor">@color/highlight_color_ics</item>
     </style>
 </resources>

--- a/java/res/values/themes-klp.xml
+++ b/java/res/values/themes-klp.xml
@@ -31,6 +31,8 @@
         <item name="moreKeysKeyboardViewForActionStyle">@style/MoreKeysKeyboardView.KLP</item>
         <item name="suggestionStripViewStyle">@style/SuggestionStripView.KLP</item>
         <item name="suggestionWordStyle">@style/SuggestionWord.KLP</item>
+        <item name="pasteButtonStyle">@style/PasteButton.KLP</item>
+        <item name="pasteButtonTextStyle">@style/PasteButtonText.KLP</item>
     </style>
     <style
         name="Keyboard.KLP"
@@ -145,6 +147,18 @@
         parent="SuggestionWord"
     >
         <item name="android:background">@drawable/btn_suggestion_klp</item>
+        <item name="android:textColor">@color/highlight_color_klp</item>
+    </style>
+    <style
+        name="PasteButton.KLP"
+        parent="PasteButton"
+    >
+        <item name="android:background">@drawable/btn_paste_holo</item>
+    </style>
+    <style
+        name="PasteButtonText.KLP"
+        parent="PasteButtonText"
+    >
         <item name="android:textColor">@color/highlight_color_klp</item>
     </style>
 </resources>

--- a/java/res/values/themes-lxx-dark.xml
+++ b/java/res/values/themes-lxx-dark.xml
@@ -30,6 +30,8 @@
         <item name="moreKeysKeyboardViewForActionStyle">@style/MoreKeysKeyboardView.LXX_Dark.Action</item>
         <item name="suggestionStripViewStyle">@style/SuggestionStripView.LXX_Dark</item>
         <item name="suggestionWordStyle">@style/SuggestionWord.LXX_Dark</item>
+        <item name="pasteButtonStyle">@style/PasteButton.LXX_Dark</item>
+        <item name="pasteButtonTextStyle">@style/PasteButtonText.LXX_Dark</item>
     </style>
     <style
         name="Keyboard.LXX_Dark"
@@ -153,5 +155,17 @@
     >
         <item name="android:background">@drawable/btn_suggestion_lxx_dark</item>
         <item name="android:textColor">@color/highlight_color_lxx_dark</item>
+    </style>
+    <style
+        name="PasteButton.LXX_Dark"
+        parent="PasteButton"
+    >
+        <item name="android:background">@drawable/btn_paste_holo</item>
+    </style>
+    <style
+        name="PasteButtonText.LXX_Dark"
+        parent="PasteButtonText"
+    >
+        <item name="android:textColor">@color/key_text_color_lxx_dark</item>
     </style>
 </resources>

--- a/java/res/values/themes-lxx-light.xml
+++ b/java/res/values/themes-lxx-light.xml
@@ -30,6 +30,8 @@
         <item name="moreKeysKeyboardViewForActionStyle">@style/MoreKeysKeyboardView.LXX_Light.Action</item>
         <item name="suggestionStripViewStyle">@style/SuggestionStripView.LXX_Light</item>
         <item name="suggestionWordStyle">@style/SuggestionWord.LXX_Light</item>
+        <item name="pasteButtonStyle">@style/PasteButton.LXX_Light</item>
+        <item name="pasteButtonTextStyle">@style/PasteButtonText.LXX_Light</item>
     </style>
     <style
         name="Keyboard.LXX_Light"
@@ -153,5 +155,17 @@
     >
         <item name="android:background">@drawable/btn_suggestion_lxx_light</item>
         <item name="android:textColor">@color/highlight_color_lxx_light</item>
+    </style>
+    <style
+        name="PasteButton.LXX_Light"
+        parent="PasteButton"
+    >
+        <item name="android:background">@drawable/btn_paste_lxx_light</item>
+    </style>
+    <style
+        name="PasteButtonText.LXX_Light"
+        parent="PasteButtonText"
+    >
+        <item name="android:textColor">@color/key_text_color_lxx_light</item>
     </style>
 </resources>

--- a/java/res/xml/prefs_screen_preferences.xml
+++ b/java/res/xml/prefs_screen_preferences.xml
@@ -46,6 +46,12 @@
         android:defaultValue="@bool/config_default_key_preview_popup"
         android:persistent="true" />
     <CheckBoxPreference
+        android:key="show_paste_button"
+        android:summary="@string/prefs_show_paste_button_summary"
+        android:title="@string/prefs_show_paste_button"
+        android:defaultValue="@bool/config_default_show_paste_button"
+        android:persistent="true" />
+    <CheckBoxPreference
         android:key="pref_voice_input_key"
         android:title="@string/voice_input"
         android:defaultValue="true"

--- a/java/src/com/android/inputmethod/latin/InputAttributes.java
+++ b/java/src/com/android/inputmethod/latin/InputAttributes.java
@@ -16,6 +16,7 @@
 
 package com.android.inputmethod.latin;
 
+import static com.android.inputmethod.latin.common.Constants.ImeOption.NO_CLIPBOARD_PASTE;
 import static com.android.inputmethod.latin.common.Constants.ImeOption.NO_FLOATING_GESTURE_PREVIEW;
 import static com.android.inputmethod.latin.common.Constants.ImeOption.NO_MICROPHONE;
 import static com.android.inputmethod.latin.common.Constants.ImeOption.NO_MICROPHONE_COMPAT;
@@ -43,6 +44,7 @@ public final class InputAttributes {
     final public boolean mApplicationSpecifiedCompletionOn;
     final public boolean mShouldInsertSpacesAutomatically;
     final public boolean mShouldShowVoiceInputKey;
+    final public boolean mAllowsClipboardPaste;
     /**
      * Whether the floating gesture preview should be disabled. If true, this should override the
      * corresponding keyboard settings preference, always suppressing the floating preview text.
@@ -59,6 +61,8 @@ public final class InputAttributes {
         mEditorInfo = editorInfo;
         mPackageNameForPrivateImeOptions = packageNameForPrivateImeOptions;
         mTargetApplicationPackageName = null != editorInfo ? editorInfo.packageName : null;
+        mAllowsClipboardPaste = !inPrivateImeOptions(
+                packageNameForPrivateImeOptions, NO_CLIPBOARD_PASTE, editorInfo);
         final int inputType = null != editorInfo ? editorInfo.inputType : 0;
         final int inputClass = inputType & InputType.TYPE_MASK_CLASS;
         mInputType = inputType;

--- a/java/src/com/android/inputmethod/latin/LatinIME.java
+++ b/java/src/com/android/inputmethod/latin/LatinIME.java
@@ -202,6 +202,9 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     private final boolean mIsHardwareAcceleratedDrawingEnabled;
 
     private GestureConsumer mGestureConsumer = GestureConsumer.NULL_GESTURE_CONSUMER;
+    // The worker finishes before its tail result reaches the UI. Keep paste hidden until that
+    // result has updated the editor and suggestion strip.
+    private volatile boolean mBatchInputUiActive;
 
     public final UIHandler mHandler = new UIHandler(this);
 
@@ -218,8 +221,9 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         private static final int MSG_DEALLOCATE_MEMORY = 9;
         private static final int MSG_RESUME_SUGGESTIONS_FOR_START_INPUT = 10;
         private static final int MSG_SWITCH_LANGUAGE_AUTOMATICALLY = 11;
+        private static final int MSG_REFRESH_PASTE_ACTIONS = 12;
         // Update this when adding new messages
-        private static final int MSG_LAST = MSG_SWITCH_LANGUAGE_AUTOMATICALLY;
+        private static final int MSG_LAST = MSG_REFRESH_PASTE_ACTIONS;
 
         private static final int ARG1_NOT_GESTURE_INPUT = 0;
         private static final int ARG1_DISMISS_GESTURE_FLOATING_PREVIEW_TEXT = 1;
@@ -315,6 +319,12 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
                 break;
             case MSG_SWITCH_LANGUAGE_AUTOMATICALLY:
                 latinIme.switchLanguage((InputMethodSubtype)msg.obj);
+                break;
+            case MSG_REFRESH_PASTE_ACTIONS:
+                if (latinIme.hasSuggestionStripView() && latinIme.isInputViewShown()) {
+                    latinIme.updatePasteActionStateAndStripVisibility(
+                            latinIme.mSettings.getCurrent(), latinIme.mInputLogic.mSuggestedWords);
+                }
                 break;
             }
         }
@@ -436,6 +446,11 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
 
         public void postSwitchLanguage(final InputMethodSubtype subtype) {
             obtainMessage(MSG_SWITCH_LANGUAGE_AUTOMATICALLY, subtype).sendToTarget();
+        }
+
+        public void postRefreshPasteActions() {
+            removeMessages(MSG_REFRESH_PASTE_ACTIONS);
+            sendEmptyMessage(MSG_REFRESH_PASTE_ACTIONS);
         }
 
         // Working variables for the following methods.
@@ -860,6 +875,7 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         mSuggestionStripView = (SuggestionStripView)view.findViewById(R.id.suggestion_strip_view);
         if (hasSuggestionStripView()) {
             mSuggestionStripView.setListener(this, view);
+            mSuggestionStripView.resetPasteActionState();
         }
     }
 
@@ -902,10 +918,19 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         mInputLogic.onSubtypeChanged(SubtypeLocaleUtils.getCombiningRulesExtraValue(subtype),
                 mSettings.getCurrent());
         loadKeyboard();
+        exitBatchInputUi();
+        mHandler.postRefreshPasteActions();
     }
 
     void onStartInputInternal(final EditorInfo editorInfo, final boolean restarting) {
         super.onStartInput(editorInfo, restarting);
+
+        exitBatchInputUi();
+        if (hasSuggestionStripView()) {
+            // The input view can survive an editor switch, but clipboard presentation state must
+            // not carry over to the next EditorInfo while its settings are being loaded.
+            mSuggestionStripView.resetPasteActionState();
+        }
 
         // If the primary hint language does not match the current subtype language, then try
         // to switch to the primary hint language.
@@ -1124,10 +1149,14 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     }
 
     private void cleanupInternalStateForFinishInput() {
+        exitBatchInputUi();
         // Remove pending messages related to update suggestions
         mHandler.cancelUpdateSuggestionStrip();
         // Should do the following in onFinishInputInternal but until JB MR2 it's not called :(
         mInputLogic.finishInput();
+        if (hasSuggestionStripView()) {
+            mSuggestionStripView.resetPasteActionState();
+        }
     }
 
     protected void deallocateMemory() {
@@ -1151,11 +1180,20 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         // view is not displayed we have no means of showing suggestions anyway, and if it is then
         // we want to show suggestions anyway.
         final SettingsValues settingsValues = mSettings.getCurrent();
-        if (isInputViewShown()
-                && mInputLogic.onUpdateSelection(oldSelStart, oldSelEnd, newSelStart, newSelEnd,
-                        settingsValues)) {
-            mKeyboardSwitcher.requestUpdatingShiftState(getCurrentAutoCapsState(),
-                    getCurrentRecapitalizeState());
+        boolean cursorMovedByUser = false;
+        if (isInputViewShown()) {
+            cursorMovedByUser = mInputLogic.onUpdateSelection(
+                    oldSelStart, oldSelEnd, newSelStart, newSelEnd, settingsValues);
+            if (cursorMovedByUser) {
+                mKeyboardSwitcher.requestUpdatingShiftState(getCurrentAutoCapsState(),
+                        getCurrentRecapitalizeState());
+            }
+        }
+        if (isInputViewShown() && hasSuggestionStripView()) {
+            if (cursorMovedByUser) {
+                mSuggestionStripView.closeTemporaryPasteMode();
+            }
+            updatePasteActionState(settingsValues, mInputLogic.mSuggestedWords);
         }
     }
 
@@ -1514,8 +1552,25 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
     }
 
     @Override
+    public boolean onPaste() {
+        // The standard Paste action lets the platform grant the focused app clipboard access and
+        // preserves its receive content behavior without exposing the clip to LatinIME.
+        return mInputLogic.mConnection.performContextMenuAction(android.R.id.paste);
+    }
+
+    @Override
+    public boolean isTextFieldEmpty() {
+        return mInputLogic.mConnection.isTextFieldEmpty();
+    }
+
+    @Override
     public void onStartBatchInput() {
+        mBatchInputUiActive = true;
         mInputLogic.onStartBatchInput(mSettings.getCurrent(), mKeyboardSwitcher, mHandler);
+        if (hasSuggestionStripView()) {
+            updatePasteActionStateAndStripVisibility(
+                    mSettings.getCurrent(), mInputLogic.mSuggestedWords);
+        }
         mGestureConsumer.onGestureStarted(
                 mRichImm.getCurrentSubtypeLocale(),
                 mKeyboardSwitcher.getKeyboard());
@@ -1534,7 +1589,12 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
 
     @Override
     public void onCancelBatchInput() {
+        exitBatchInputUi();
         mInputLogic.onCancelBatchInput(mHandler);
+        if (hasSuggestionStripView()) {
+            updatePasteActionStateAndStripVisibility(
+                    mSettings.getCurrent(), mInputLogic.mSuggestedWords);
+        }
         mGestureConsumer.onGestureCanceled();
     }
 
@@ -1546,6 +1606,11 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
      * @param suggestedWords suggested words by the IME for the full gesture.
      */
     public void onTailBatchInputResultShown(final SuggestedWords suggestedWords) {
+        exitBatchInputUi();
+        if (hasSuggestionStripView()) {
+            updatePasteActionStateAndStripVisibility(
+                    mSettings.getCurrent(), mInputLogic.mSuggestedWords);
+        }
         mGestureConsumer.onImeSuggestionsProcessed(suggestedWords,
                 mInputLogic.getComposingStart(), mInputLogic.getComposingLength(),
                 mDictionaryFacilitator);
@@ -1579,6 +1644,57 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
         return null != mSuggestionStripView;
     }
 
+    private void exitBatchInputUi() {
+        mBatchInputUiActive = false;
+    }
+
+    private boolean areSuggestionCandidatesEnabled(final SettingsValues settingsValues) {
+        return (settingsValues.mInputAttributes.mShouldShowSuggestions
+                && settingsValues.isSuggestionsEnabledPerUserSettings())
+                || settingsValues.isApplicationSpecifiedCompletionsOn();
+    }
+
+    private boolean isPasteActionEligible(final SettingsValues settingsValues) {
+        return settingsValues.mShowsPasteButton
+                && settingsValues.mInputAttributes.mAllowsClipboardPaste
+                && !settingsValues.mInputAttributes.isTypeNull()
+                && !mBatchInputUiActive;
+    }
+
+    private boolean updatePasteActionState(final SettingsValues settingsValues,
+            final SuggestedWords suggestedWords) {
+        final boolean eligible = isPasteActionEligible(settingsValues);
+        // Determine from local state whether editor text could affect the choice between Paste
+        // and suggestions. The controller checks clipboard availability before querying text.
+        final boolean suggestionsCanTakePriority = eligible
+                && !settingsValues.mInputAttributes.mIsPasswordField
+                && SuggestionStripView.canSuggestionsTakePriority(
+                        areSuggestionCandidatesEnabled(settingsValues),
+                        settingsValues.mGestureFloatingPreviewTextEnabled,
+                        settingsValues.mShouldShowLxxSuggestionUi, suggestedWords);
+        return mSuggestionStripView.updatePasteActionState(
+                eligible, suggestionsCanTakePriority);
+    }
+
+    private void updatePasteActionStateAndStripVisibility(final SettingsValues settingsValues,
+            final SuggestedWords suggestedWords) {
+        final boolean hasPasteAction = updatePasteActionState(settingsValues, suggestedWords);
+        updateSuggestionStripVisibility(settingsValues,
+                ImportantNoticeUtils.shouldShowImportantNotice(this, settingsValues),
+                hasPasteAction);
+    }
+
+    private boolean updateSuggestionStripVisibility(final SettingsValues settingsValues,
+            final boolean shouldShowImportantNotice, final boolean hasPasteAction) {
+        final boolean shouldShow = hasPasteAction
+                || (!settingsValues.mInputAttributes.mIsPasswordField
+                        && (shouldShowImportantNotice
+                                || settingsValues.mShowsVoiceInputKey
+                                || areSuggestionCandidatesEnabled(settingsValues)));
+        mSuggestionStripView.updateVisibility(shouldShow, isFullscreenMode());
+        return shouldShow;
+    }
+
     private void setSuggestedWords(final SuggestedWords suggestedWords) {
         final SettingsValues currentSettingsValues = mSettings.getCurrent();
         mInputLogic.setSuggestedWords(suggestedWords);
@@ -1592,16 +1708,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
 
         final boolean shouldShowImportantNotice =
                 ImportantNoticeUtils.shouldShowImportantNotice(this, currentSettingsValues);
-        final boolean shouldShowSuggestionCandidates =
-                currentSettingsValues.mInputAttributes.mShouldShowSuggestions
-                && currentSettingsValues.isSuggestionsEnabledPerUserSettings();
-        final boolean shouldShowSuggestionsStripUnlessPassword = shouldShowImportantNotice
-                || currentSettingsValues.mShowsVoiceInputKey
-                || shouldShowSuggestionCandidates
-                || currentSettingsValues.isApplicationSpecifiedCompletionsOn();
-        final boolean shouldShowSuggestionsStrip = shouldShowSuggestionsStripUnlessPassword
-                && !currentSettingsValues.mInputAttributes.mIsPasswordField;
-        mSuggestionStripView.updateVisibility(shouldShowSuggestionsStrip, isFullscreenMode());
+        final boolean hasPasteAction = updatePasteActionState(
+                currentSettingsValues, suggestedWords);
+        final boolean shouldShowSuggestionsStrip = updateSuggestionStripVisibility(
+                currentSettingsValues, shouldShowImportantNotice, hasPasteAction);
         if (!shouldShowSuggestionsStrip) {
             return;
         }
@@ -1629,6 +1739,16 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             mSuggestionStripView.setSuggestions(suggestedWords,
                     mRichImm.getCurrentSubtype().isRtlSubtype());
         }
+    }
+
+    @Override
+    public void onPasteActionAvailabilityChanged() {
+        if (!hasSuggestionStripView() || !onEvaluateInputViewShown()) {
+            return;
+        }
+        final SettingsValues settingsValues = mSettings.getCurrent();
+        updatePasteActionStateAndStripVisibility(
+                settingsValues, mInputLogic.mSuggestedWords);
     }
 
     // TODO[IL]: Move this out of LatinIME.
@@ -1725,6 +1845,10 @@ public class LatinIME extends InputMethodService implements KeyboardActionListen
             mHandler.postUpdateSuggestionStrip(inputStyle);
         }
         if (inputTransaction.didAffectContents()) {
+            if (hasSuggestionStripView() && onEvaluateInputViewShown()) {
+                mSuggestionStripView.closeTemporaryPasteMode();
+                updatePasteActionState(mSettings.getCurrent(), mInputLogic.mSuggestedWords);
+            }
             mSubtypeState.setCurrentSubtypeHasBeenUsed();
         }
     }

--- a/java/src/com/android/inputmethod/latin/RichInputConnection.java
+++ b/java/src/com/android/inputmethod/latin/RichInputConnection.java
@@ -448,6 +448,16 @@ public final class RichInputConnection implements PrivateCommandPerformer {
                 n, flags);
     }
 
+    public boolean isTextFieldEmpty() {
+        // Cursor position zero alone cannot distinguish an empty field from the start of a
+        // nonempty field, so verify that no text follows the cursor.
+        if (mExpectedSelStart != 0 || mExpectedSelEnd != 0 || hasSlowInputConnection()) {
+            return false;
+        }
+        final CharSequence textAfterCursor = getTextAfterCursor(1, 0 /* flags */);
+        return textAfterCursor != null && textAfterCursor.length() == 0;
+    }
+
     private CharSequence getTextAfterCursorAndDetectLaggyConnection(
             final int operation, final long timeout, final int n, final int flags) {
         mIC = mParent.getCurrentInputConnection();
@@ -505,6 +515,11 @@ public final class RichInputConnection implements PrivateCommandPerformer {
         if (isConnected()) {
             mIC.performEditorAction(actionId);
         }
+    }
+
+    public boolean performContextMenuAction(final int actionId) {
+        mIC = mParent.getCurrentInputConnection();
+        return isConnected() && mIC.performContextMenuAction(actionId);
     }
 
     public void sendKeyEvent(final KeyEvent keyEvent) {

--- a/java/src/com/android/inputmethod/latin/settings/PreferencesSettingsFragment.java
+++ b/java/src/com/android/inputmethod/latin/settings/PreferencesSettingsFragment.java
@@ -36,6 +36,7 @@ import com.android.inputmethod.latin.RichInputMethodManager;
  * - Vibrate on keypress
  * - Sound on keypress
  * - Popup on keypress
+ * - Show paste button
  * - Voice input key
  */
 public final class PreferencesSettingsFragment extends SubScreenFragment {

--- a/java/src/com/android/inputmethod/latin/settings/Settings.java
+++ b/java/src/com/android/inputmethod/latin/settings/Settings.java
@@ -65,6 +65,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     // PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE is obsolete. Use PREF_SHOW_SUGGESTIONS instead.
     public static final String PREF_SHOW_SUGGESTIONS_SETTING_OBSOLETE = "show_suggestions_setting";
     public static final String PREF_SHOW_SUGGESTIONS = "show_suggestions";
+    public static final String PREF_SHOW_PASTE_BUTTON = "show_paste_button";
     public static final String PREF_KEY_USE_CONTACTS_DICT = "pref_key_use_contacts_dict";
     public static final String PREF_KEY_USE_PERSONALIZED_DICTS = "pref_key_use_personalized_dicts";
     public static final String PREF_KEY_USE_DOUBLE_SPACE_PERIOD =

--- a/java/src/com/android/inputmethod/latin/settings/SettingsValues.java
+++ b/java/src/com/android/inputmethod/latin/settings/SettingsValues.java
@@ -67,6 +67,7 @@ public class SettingsValues {
     public final boolean mSoundOn;
     public final boolean mKeyPreviewPopupOn;
     public final boolean mShowsVoiceInputKey;
+    public final boolean mShowsPasteButton;
     public final boolean mIncludesOtherImesInLanguageSwitchList;
     public final boolean mShowsLanguageSwitchKey;
     public final boolean mUseContactsDict;
@@ -140,6 +141,8 @@ public class SettingsValues {
         mShowsVoiceInputKey = needsToShowVoiceInputKey(prefs, res)
                 && mInputAttributes.mShouldShowVoiceInputKey
                 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
+        mShowsPasteButton = prefs.getBoolean(Settings.PREF_SHOW_PASTE_BUTTON,
+                res.getBoolean(R.bool.config_default_show_paste_button));
         mIncludesOtherImesInLanguageSwitchList = Settings.ENABLE_SHOW_LANGUAGE_SWITCH_KEY_SETTINGS
                 ? prefs.getBoolean(Settings.PREF_INCLUDE_OTHER_IMES_IN_LANGUAGE_SWITCH_LIST, false)
                 : true /* forcibly */;
@@ -386,6 +389,8 @@ public class SettingsValues {
         sb.append("" + mKeyPreviewPopupOn);
         sb.append("\n   mShowsVoiceInputKey = ");
         sb.append("" + mShowsVoiceInputKey);
+        sb.append("\n   mShowsPasteButton = ");
+        sb.append("" + mShowsPasteButton);
         sb.append("\n   mIncludesOtherImesInLanguageSwitchList = ");
         sb.append("" + mIncludesOtherImesInLanguageSwitchList);
         sb.append("\n   mShowsLanguageSwitchKey = ");

--- a/java/src/com/android/inputmethod/latin/suggestions/ClipboardAvailabilityMonitor.java
+++ b/java/src/com/android/inputmethod/latin/suggestions/ClipboardAvailabilityMonitor.java
@@ -1,0 +1,202 @@
+package com.android.inputmethod.latin.suggestions;
+
+import android.app.KeyguardManager;
+import android.content.BroadcastReceiver;
+import android.content.ClipDescription;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.view.View;
+
+import java.util.concurrent.TimeUnit;
+
+/** Tracks clipboard availability from metadata without reading or retaining clipboard contents. */
+final class ClipboardAvailabilityMonitor
+        implements ClipboardManager.OnPrimaryClipChangedListener {
+    private static final long REFRESH_DELAY_MILLIS = 100;
+    private static final long AUTOMATIC_OFFER_MAX_AGE_MILLIS = TimeUnit.MINUTES.toMillis(2);
+    private static final long NO_CLIP_TIMESTAMP = Long.MIN_VALUE;
+    private static final String PREFERENCES_FILE = "paste_action_state";
+    private static final String PREF_LAST_DISPATCHED_CLIP_TIMESTAMP =
+            "suggestion_strip_last_dispatched_clip_timestamp";
+    private static final String CONTROL_KEYGUARD_PERMISSION =
+            "android.permission.CONTROL_KEYGUARD";
+
+    interface Listener {
+        void onClipboardAvailabilityChanged(boolean available);
+    }
+
+    private final Context mContext;
+    private final ClipboardManager mClipboardManager;
+    private final KeyguardManager mKeyguardManager;
+    private final SharedPreferences mPreferences;
+    private final View mCallbackView;
+    private final Listener mListener;
+
+    private boolean mActive;
+    private boolean mRefreshScheduled;
+    private long mClipTimestamp = NO_CLIP_TIMESTAMP;
+
+    private final Runnable mRefresh = new Runnable() {
+        @Override
+        public void run() {
+            mRefreshScheduled = false;
+            refreshAndNotify();
+        }
+    };
+
+    private final BroadcastReceiver mScreenStateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(final Context context, final Intent intent) {
+            if (Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                cancelPendingRefresh();
+                clearAndNotify();
+            } else if (Intent.ACTION_SCREEN_ON.equals(intent.getAction())
+                    || Intent.ACTION_USER_PRESENT.equals(intent.getAction())) {
+                refreshAndNotify();
+            }
+        }
+    };
+
+    ClipboardAvailabilityMonitor(final Context context, final View callbackView,
+            final Listener listener) {
+        mContext = context;
+        mClipboardManager = (ClipboardManager)context.getSystemService(Context.CLIPBOARD_SERVICE);
+        mKeyguardManager = context.getSystemService(KeyguardManager.class);
+        mPreferences = context.getSharedPreferences(PREFERENCES_FILE, Context.MODE_PRIVATE);
+        mCallbackView = callbackView;
+        mListener = listener;
+    }
+
+    boolean setActive(final boolean active) {
+        if (mActive == active) {
+            return isClipboardAvailable();
+        }
+        if (!active) {
+            stop();
+            return isClipboardAvailable();
+        }
+
+        mActive = true;
+        mClipboardManager.addPrimaryClipChangedListener(this);
+        // Clipboard callbacks do not report lock transitions, so resample around screen and
+        // keyguard interaction changes. Protected broadcasts plus the signature permission stop
+        // apps from driving this exported receiver; USER_PRESENT is sent across UIDs by SystemUI.
+        final IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
+        filter.addAction(Intent.ACTION_SCREEN_ON);
+        filter.addAction(Intent.ACTION_USER_PRESENT);
+        mContext.registerReceiver(mScreenStateReceiver, filter, CONTROL_KEYGUARD_PERMISSION,
+                null /* scheduler */, Context.RECEIVER_EXPORTED);
+        refreshClipboardState();
+        return isClipboardAvailable();
+    }
+
+    boolean refresh() {
+        cancelPendingRefresh();
+        refreshClipboardState();
+        return isClipboardAvailable();
+    }
+
+    boolean shouldOfferAutomatically() {
+        // Age is intentionally sampled lazily; an already visible chip does not need an expiry
+        // timer.
+        final long clipAgeMillis = System.currentTimeMillis() - mClipTimestamp;
+        return isClipboardAvailable()
+                && clipAgeMillis >= 0
+                && clipAgeMillis < AUTOMATIC_OFFER_MAX_AGE_MILLIS
+                && mClipTimestamp != mPreferences.getLong(
+                        PREF_LAST_DISPATCHED_CLIP_TIMESTAMP, NO_CLIP_TIMESTAMP);
+    }
+
+    void markCurrentClipDispatched() {
+        if (!isClipboardAvailable()) {
+            return;
+        }
+        // Persistence prevents the same clip from being offered again after an editor or process
+        // change. The timestamp is clipboard metadata and does not reveal the copied value.
+        mPreferences.edit().putLong(PREF_LAST_DISPATCHED_CLIP_TIMESTAMP, mClipTimestamp).apply();
+    }
+
+    private void stop() {
+        cancelPendingRefresh();
+        if (mActive) {
+            mClipboardManager.removePrimaryClipChangedListener(this);
+            mContext.unregisterReceiver(mScreenStateReceiver);
+            mActive = false;
+        }
+        clearClipboardState();
+    }
+
+    @Override
+    public void onPrimaryClipChanged() {
+        // Coalesce rapid replacements so clipboard writers cannot make every callback perform a
+        // synchronous service query on the keyboard UI thread.
+        if (!mActive || mRefreshScheduled) {
+            return;
+        }
+        mRefreshScheduled = true;
+        if (!mCallbackView.postDelayed(mRefresh, REFRESH_DELAY_MILLIS)) {
+            mRefreshScheduled = false;
+        }
+    }
+
+    private void cancelPendingRefresh() {
+        if (!mRefreshScheduled) {
+            return;
+        }
+        mCallbackView.removeCallbacks(mRefresh);
+        mRefreshScheduled = false;
+    }
+
+    private void refreshAndNotify() {
+        cancelPendingRefresh();
+        final boolean wasAvailable = isClipboardAvailable();
+        final boolean wasAutomaticallyOffered = shouldOfferAutomatically();
+        refreshClipboardState();
+        if (wasAvailable != isClipboardAvailable()
+                || wasAutomaticallyOffered != shouldOfferAutomatically()) {
+            mListener.onClipboardAvailabilityChanged(isClipboardAvailable());
+        }
+    }
+
+    private void clearAndNotify() {
+        if (!isClipboardAvailable()) {
+            return;
+        }
+        clearClipboardState();
+        mListener.onClipboardAvailabilityChanged(false);
+    }
+
+    private void clearClipboardState() {
+        mClipTimestamp = NO_CLIP_TIMESTAMP;
+    }
+
+    private boolean isClipboardAvailable() {
+        return mClipTimestamp != NO_CLIP_TIMESTAMP;
+    }
+
+    private void refreshClipboardState() {
+        // ClipboardService also withholds clipboard state while the device is locked. The explicit
+        // check removes a cached action promptly, so the strip does not offer a paste that platform
+        // policy will reject.
+        // Do not read ClipData here. A full read can grant content URIs before the user chooses an
+        // action; the focused editor reads and handles the clip after the action is dispatched.
+        if (!mActive || mKeyguardManager == null || mKeyguardManager.isDeviceLocked()) {
+            clearClipboardState();
+            return;
+        }
+        final ClipDescription description = mClipboardManager.getPrimaryClipDescription();
+        // The chip invokes the editor's generic Paste action, which can deliver content through a
+        // receive content handler even when EditorInfo.contentMimeTypes does not advertise support
+        // for the separate InputConnection.commitContent() API. Match the clipboard availability
+        // check in TextView.canPaste() by offering Paste for every clip, then let the focused
+        // editor decide whether to consume it.
+        if (description == null) {
+            clearClipboardState();
+            return;
+        }
+        mClipTimestamp = description.getTimestamp();
+    }
+}

--- a/java/src/com/android/inputmethod/latin/suggestions/PasteActionState.java
+++ b/java/src/com/android/inputmethod/latin/suggestions/PasteActionState.java
@@ -1,0 +1,80 @@
+package com.android.inputmethod.latin.suggestions;
+
+/** Keeps clipboard availability separate from whether the current clip is offered automatically. */
+final class PasteActionState {
+    enum SideButtonMode {
+        NONE,
+        OPEN_PASTE_MODE,
+        CLOSE_PASTE_MODE,
+    }
+
+    private boolean mEligible;
+    private boolean mClipboardAvailable;
+    private boolean mAutomaticallyOffer;
+    private boolean mSuggestionsTakePriority;
+    private boolean mTemporaryMode;
+
+    public void updateContext(final boolean eligible, final boolean suggestionsTakePriority) {
+        mEligible = eligible;
+        mSuggestionsTakePriority = suggestionsTakePriority;
+        // The caller closes temporary mode when the editor changes or new suggestions arrive.
+        if (!eligible) {
+            mTemporaryMode = false;
+        }
+    }
+
+    public void setClipboardAvailability(final boolean available,
+            final boolean automaticallyOffer) {
+        mClipboardAvailable = available;
+        mAutomaticallyOffer = available && automaticallyOffer;
+        if (!available) {
+            mTemporaryMode = false;
+        }
+    }
+
+    public void openTemporaryMode() {
+        if (getSideButtonMode() != SideButtonMode.OPEN_PASTE_MODE) {
+            return;
+        }
+        mTemporaryMode = true;
+    }
+
+    public void closeTemporaryMode() {
+        mTemporaryMode = false;
+    }
+
+    public void reset() {
+        mEligible = false;
+        mClipboardAvailable = false;
+        mAutomaticallyOffer = false;
+        mSuggestionsTakePriority = false;
+        mTemporaryMode = false;
+    }
+
+    public boolean shouldMonitorClipboard() {
+        return mEligible;
+    }
+
+    public boolean hasPasteAction() {
+        return mEligible && mClipboardAvailable;
+    }
+
+    public boolean shouldShowPasteActions() {
+        return hasPasteAction()
+                && (mTemporaryMode || (mAutomaticallyOffer && !mSuggestionsTakePriority));
+    }
+
+    public boolean shouldOfferPasteAutomatically() {
+        return hasPasteAction() && mAutomaticallyOffer;
+    }
+
+    public SideButtonMode getSideButtonMode() {
+        if (hasPasteAction() && mTemporaryMode) {
+            return SideButtonMode.CLOSE_PASTE_MODE;
+        }
+        if (hasPasteAction() && (mSuggestionsTakePriority || !mAutomaticallyOffer)) {
+            return SideButtonMode.OPEN_PASTE_MODE;
+        }
+        return SideButtonMode.NONE;
+    }
+}

--- a/java/src/com/android/inputmethod/latin/suggestions/SuggestionStripPasteController.java
+++ b/java/src/com/android/inputmethod/latin/suggestions/SuggestionStripPasteController.java
@@ -1,0 +1,276 @@
+package com.android.inputmethod.latin.suggestions;
+
+import android.content.Context;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.HorizontalScrollView;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.core.view.ViewCompat;
+
+import com.android.inputmethod.latin.R;
+
+/** Owns clipboard observation and Paste presentation in the suggestion strip. */
+final class SuggestionStripPasteController
+        implements ClipboardAvailabilityMonitor.Listener {
+    interface Listener {
+        boolean onPaste();
+        boolean isTextFieldEmpty();
+        void onPasteActionAvailabilityChanged();
+    }
+
+    private static final long PASTE_BUTTON_REENABLE_DELAY_MILLIS = 500;
+
+    private final View mRootView;
+    private final View mSuggestionsStrip;
+    private final View mImportantNoticeStrip;
+    private final HorizontalScrollView mPasteActions;
+    private final ImageButton mPasteModeKey;
+    private final View mPasteButton;
+    private final Runnable mDismissMoreSuggestions;
+    private final ClipboardAvailabilityMonitor mClipboardMonitor;
+    private final PasteActionState mState = new PasteActionState();
+
+    private Listener mListener;
+
+    private final Runnable mReenablePasteButton = new Runnable() {
+        @Override
+        public void run() {
+            mPasteButton.setEnabled(true);
+        }
+    };
+
+    private final Runnable mAlignPasteActions = new Runnable() {
+        @Override
+        public void run() {
+            final View content = mPasteActions.getChildAt(0);
+            final int scrollX = ViewCompat.getLayoutDirection(mPasteActions)
+                    == ViewCompat.LAYOUT_DIRECTION_RTL
+                    ? Math.max(0, content.getWidth() - mPasteActions.getWidth()) : 0;
+            mPasteActions.scrollTo(scrollX, 0);
+        }
+    };
+
+    SuggestionStripPasteController(final Context context, final View rootView,
+            final ViewGroup suggestionsStrip, final View importantNoticeStrip,
+            final HorizontalScrollView pasteActions, final ImageButton pasteModeKey,
+            final View pasteButton, final ImageView pasteButtonIcon,
+            final TextView pasteButtonText, final OnClickListener clickListener,
+            final Runnable dismissMoreSuggestions) {
+        mRootView = rootView;
+        mSuggestionsStrip = suggestionsStrip;
+        mImportantNoticeStrip = importantNoticeStrip;
+        mPasteActions = pasteActions;
+        mPasteModeKey = pasteModeKey;
+        mPasteButton = pasteButton;
+        mDismissMoreSuggestions = dismissMoreSuggestions;
+        mClipboardMonitor = new ClipboardAvailabilityMonitor(context, rootView, this);
+
+        mPasteActions.setFocusable(false);
+        pasteButtonIcon.setImageTintList(pasteButtonText.getTextColors());
+        mPasteModeKey.setImageTintList(pasteButtonText.getTextColors());
+        mPasteModeKey.setOnClickListener(clickListener);
+        mPasteButton.setOnClickListener(clickListener);
+        showSuggestionsStrip();
+    }
+
+    void setListener(final Listener listener) {
+        mListener = listener;
+    }
+
+    void setLayoutDirection(final boolean isRtlLanguage) {
+        final int layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL
+                : ViewCompat.LAYOUT_DIRECTION_LTR;
+        ViewCompat.setLayoutDirection(mRootView, layoutDirection);
+        ViewCompat.setLayoutDirection(mSuggestionsStrip, layoutDirection);
+        ViewCompat.setLayoutDirection(mImportantNoticeStrip, layoutDirection);
+        ViewCompat.setLayoutDirection(mPasteActions, layoutDirection);
+        ViewCompat.setLayoutDirection(mPasteModeKey, layoutDirection);
+    }
+
+    void showSuggestionsStrip() {
+        mSuggestionsStrip.setVisibility(View.VISIBLE);
+        mImportantNoticeStrip.setVisibility(View.INVISIBLE);
+        mPasteActions.setVisibility(View.INVISIBLE);
+    }
+
+    void showImportantNoticeStrip() {
+        mState.closeTemporaryMode();
+        mSuggestionsStrip.setVisibility(View.INVISIBLE);
+        mImportantNoticeStrip.setVisibility(View.VISIBLE);
+        mPasteActions.setVisibility(View.INVISIBLE);
+        mPasteModeKey.setVisibility(View.INVISIBLE);
+    }
+
+    boolean isShowingSuggestionsStrip() {
+        return mSuggestionsStrip.getVisibility() == View.VISIBLE;
+    }
+
+    boolean updateState(final boolean eligible, final boolean suggestionsCanTakePriority) {
+        mState.updateContext(eligible, false /* suggestionsTakePriority */);
+        refreshClipboardAvailabilityState();
+        // InputConnection queries can block the UI thread. Ask about editor text only when an
+        // available clip and visible suggestions make the answer affect presentation.
+        final boolean suggestionsTakePriority = mState.shouldOfferPasteAutomatically()
+                && suggestionsCanTakePriority
+                && mListener != null
+                && !mListener.isTextFieldEmpty();
+        mState.updateContext(eligible, suggestionsTakePriority);
+        updatePresentation();
+        return mState.hasPasteAction();
+    }
+
+    void onSuggestionsShown() {
+        mState.closeTemporaryMode();
+        showSuggestionsStrip();
+        updatePresentation();
+    }
+
+    void closeTemporaryMode() {
+        mState.closeTemporaryMode();
+        updatePresentation();
+    }
+
+    void reset() {
+        cancelPasteButtonDebounce();
+        mPasteActions.removeCallbacks(mAlignPasteActions);
+        mState.reset();
+        mClipboardMonitor.setActive(false);
+        updatePresentation();
+    }
+
+    private void cancelPasteButtonDebounce() {
+        mPasteButton.removeCallbacks(mReenablePasteButton);
+        mPasteButton.setEnabled(true);
+    }
+
+    @Override
+    public void onClipboardAvailabilityChanged(final boolean available) {
+        updateClipboardAvailability(available, true /* notifyAvailabilityChange */);
+    }
+
+    private void synchronizeClipboardAvailability(final boolean notifyAvailabilityChange) {
+        // A hidden keyboard should neither observe clipboard changes nor inspect its state.
+        final boolean availabilityChanged = refreshClipboardAvailabilityState();
+        updatePresentation();
+        if (notifyAvailabilityChange && availabilityChanged && mListener != null) {
+            mListener.onPasteActionAvailabilityChanged();
+        }
+    }
+
+    private boolean refreshClipboardAvailabilityState() {
+        final boolean active = mState.shouldMonitorClipboard()
+                && mRootView.isAttachedToWindow()
+                && mRootView.getWindowVisibility() == View.VISIBLE;
+        return setClipboardAvailability(mClipboardMonitor.setActive(active));
+    }
+
+    private void updateClipboardAvailability(final boolean available,
+            final boolean notifyAvailabilityChange) {
+        final boolean availabilityChanged = setClipboardAvailability(available);
+        updatePresentation();
+        if (notifyAvailabilityChange && availabilityChanged && mListener != null) {
+            mListener.onPasteActionAvailabilityChanged();
+        }
+    }
+
+    private boolean setClipboardAvailability(final boolean available) {
+        final boolean wasAvailable = mState.hasPasteAction();
+        mState.setClipboardAvailability(available, mClipboardMonitor.shouldOfferAutomatically());
+        return wasAvailable != mState.hasPasteAction();
+    }
+
+    private void updatePresentation() {
+        // Clipboard actions must not replace the contact permission notice.
+        if (mImportantNoticeStrip.getVisibility() == View.VISIBLE) {
+            mPasteModeKey.setVisibility(View.INVISIBLE);
+            return;
+        }
+
+        if (mState.shouldShowPasteActions()) {
+            mDismissMoreSuggestions.run();
+            final boolean shouldRealign = mPasteActions.getVisibility() != View.VISIBLE;
+            mSuggestionsStrip.setVisibility(View.INVISIBLE);
+            mImportantNoticeStrip.setVisibility(View.INVISIBLE);
+            mPasteActions.setVisibility(View.VISIBLE);
+            if (shouldRealign) {
+                // Wait for measurement so an overflowing RTL row starts at its logical beginning.
+                mPasteActions.removeCallbacks(mAlignPasteActions);
+                mPasteActions.post(mAlignPasteActions);
+            }
+        } else if (mPasteActions.getVisibility() == View.VISIBLE) {
+            showSuggestionsStrip();
+        }
+
+        switch (mState.getSideButtonMode()) {
+            case CLOSE_PASTE_MODE:
+                mPasteModeKey.setImageResource(R.drawable.ic_close_paste_mode);
+                mPasteModeKey.setContentDescription(mRootView.getResources().getString(
+                        R.string.spoken_description_show_suggestions));
+                mPasteModeKey.setVisibility(View.VISIBLE);
+                break;
+            case OPEN_PASTE_MODE:
+                mPasteModeKey.setImageResource(R.drawable.ic_clipboard_action);
+                mPasteModeKey.setContentDescription(mRootView.getResources().getString(
+                        R.string.spoken_description_show_paste_button));
+                mPasteModeKey.setVisibility(View.VISIBLE);
+                break;
+            case NONE:
+                mPasteModeKey.setVisibility(View.INVISIBLE);
+                break;
+        }
+    }
+
+    boolean onClick(final View view) {
+        if (view == mPasteModeKey) {
+            if (mState.getSideButtonMode() == PasteActionState.SideButtonMode.CLOSE_PASTE_MODE) {
+                closeTemporaryMode();
+                return true;
+            }
+            // Recheck before entering the mode because clipboard callbacks may be delayed.
+            updateClipboardAvailability(mClipboardMonitor.refresh(),
+                    true /* notifyAvailabilityChange */);
+            mState.openTemporaryMode();
+            updatePresentation();
+            return true;
+        }
+        if (view != mPasteButton) {
+            return false;
+        }
+
+        updateClipboardAvailability(mClipboardMonitor.refresh(),
+                true /* notifyAvailabilityChange */);
+        if (!mState.hasPasteAction()) {
+            return true;
+        }
+        mPasteButton.setEnabled(false);
+        if (!mPasteButton.postDelayed(
+                mReenablePasteButton, PASTE_BUTTON_REENABLE_DELAY_MILLIS)) {
+            cancelPasteButtonDebounce();
+        }
+        if (mListener != null && mListener.onPaste()) {
+            // InputConnection reports dispatch, not whether the editor consumed the clip. Persist
+            // only that dispatch and its metadata timestamp; the focused editor owns the payload.
+            mClipboardMonitor.markCurrentClipDispatched();
+            mState.closeTemporaryMode();
+            updateClipboardAvailability(true /* available */, false /* notifyAvailabilityChange */);
+        }
+        return true;
+    }
+
+    void onWindowVisibilityChanged(final int visibility) {
+        if (visibility != View.VISIBLE) {
+            updateClipboardAvailability(mClipboardMonitor.setActive(false),
+                    false /* notifyAvailabilityChange */);
+            return;
+        }
+        synchronizeClipboardAvailability(false /* notifyAvailabilityChange */);
+        // The clip may have changed while clipboard monitoring was stopped.
+        if (mListener != null) {
+            mListener.onPasteActionAvailabilityChanged();
+        }
+    }
+}

--- a/java/src/com/android/inputmethod/latin/suggestions/SuggestionStripView.java
+++ b/java/src/com/android/inputmethod/latin/suggestions/SuggestionStripView.java
@@ -21,7 +21,6 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
-import androidx.core.view.ViewCompat;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -34,7 +33,9 @@ import android.view.View.OnLongClickListener;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
+import android.widget.HorizontalScrollView;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -55,12 +56,15 @@ import com.android.inputmethod.latin.utils.ImportantNoticeUtils;
 
 import java.util.ArrayList;
 
-public final class SuggestionStripView extends RelativeLayout implements OnClickListener,
-        OnLongClickListener {
+public final class SuggestionStripView extends RelativeLayout implements
+        OnClickListener, OnLongClickListener {
     public interface Listener {
         public void showImportantNoticeContents();
         public void pickSuggestionManually(SuggestedWordInfo word);
         public void onCodeInput(int primaryCode, int x, int y, boolean isKeyRepeat);
+        public boolean onPaste();
+        public boolean isTextFieldEmpty();
+        public void onPasteActionAvailabilityChanged();
     }
 
     static final boolean DBG = DebugFlags.DEBUG_ENABLED;
@@ -82,45 +86,8 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     Listener mListener;
     private SuggestedWords mSuggestedWords = SuggestedWords.getEmptyInstance();
     private int mStartIndexOfMoreSuggestions;
-
     private final SuggestionStripLayoutHelper mLayoutHelper;
-    private final StripVisibilityGroup mStripVisibilityGroup;
-
-    private static class StripVisibilityGroup {
-        private final View mSuggestionStripView;
-        private final View mSuggestionsStrip;
-        private final View mImportantNoticeStrip;
-
-        public StripVisibilityGroup(final View suggestionStripView,
-                final ViewGroup suggestionsStrip, final View importantNoticeStrip) {
-            mSuggestionStripView = suggestionStripView;
-            mSuggestionsStrip = suggestionsStrip;
-            mImportantNoticeStrip = importantNoticeStrip;
-            showSuggestionsStrip();
-        }
-
-        public void setLayoutDirection(final boolean isRtlLanguage) {
-            final int layoutDirection = isRtlLanguage ? ViewCompat.LAYOUT_DIRECTION_RTL
-                    : ViewCompat.LAYOUT_DIRECTION_LTR;
-            ViewCompat.setLayoutDirection(mSuggestionStripView, layoutDirection);
-            ViewCompat.setLayoutDirection(mSuggestionsStrip, layoutDirection);
-            ViewCompat.setLayoutDirection(mImportantNoticeStrip, layoutDirection);
-        }
-
-        public void showSuggestionsStrip() {
-            mSuggestionsStrip.setVisibility(VISIBLE);
-            mImportantNoticeStrip.setVisibility(INVISIBLE);
-        }
-
-        public void showImportantNoticeStrip() {
-            mSuggestionsStrip.setVisibility(INVISIBLE);
-            mImportantNoticeStrip.setVisibility(VISIBLE);
-        }
-
-        public boolean isShowingImportantNoticeStrip() {
-            return mImportantNoticeStrip.getVisibility() == VISIBLE;
-        }
-    }
+    private final SuggestionStripPasteController mPasteController;
 
     /**
      * Construct a {@link SuggestionStripView} for showing suggestions to be picked by the user.
@@ -141,8 +108,6 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         mSuggestionsStrip = (ViewGroup)findViewById(R.id.suggestions_strip);
         mVoiceKey = (ImageButton)findViewById(R.id.suggestions_strip_voice_key);
         mImportantNoticeStrip = findViewById(R.id.important_notice_strip);
-        mStripVisibilityGroup = new StripVisibilityGroup(this, mSuggestionsStrip,
-                mImportantNoticeStrip);
 
         for (int pos = 0; pos < SuggestedWords.MAX_SUGGESTIONS; pos++) {
             final TextView word = new TextView(context, null, R.attr.suggestionWordStyle);
@@ -165,6 +130,19 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
         mMoreSuggestionsView = (MoreSuggestionsView)mMoreSuggestionsContainer
                 .findViewById(R.id.more_suggestions_view);
         mMoreSuggestionsBuilder = new MoreSuggestions.Builder(context, mMoreSuggestionsView);
+        mPasteController = new SuggestionStripPasteController(context, this, mSuggestionsStrip,
+                mImportantNoticeStrip,
+                (HorizontalScrollView)findViewById(R.id.paste_actions),
+                (ImageButton)findViewById(R.id.suggestions_strip_paste_key),
+                findViewById(R.id.paste_button),
+                (ImageView)findViewById(R.id.paste_button_icon),
+                (TextView)findViewById(R.id.paste_button_text), this,
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        dismissMoreSuggestionsPanel();
+                    }
+                });
 
         final Resources res = context.getResources();
         mMoreSuggestionsModalTolerance = res.getDimensionPixelOffset(
@@ -186,6 +164,22 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
      */
     public void setListener(final Listener listener, final View inputView) {
         mListener = listener;
+        mPasteController.setListener(new SuggestionStripPasteController.Listener() {
+            @Override
+            public boolean onPaste() {
+                return listener.onPaste();
+            }
+
+            @Override
+            public boolean isTextFieldEmpty() {
+                return listener.isTextFieldEmpty();
+            }
+
+            @Override
+            public void onPasteActionAvailabilityChanged() {
+                listener.onPasteActionAvailabilityChanged();
+            }
+        });
         mMainKeyboardView = (MainKeyboardView)inputView.findViewById(R.id.keyboard_view);
     }
 
@@ -198,11 +192,40 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
 
     public void setSuggestions(final SuggestedWords suggestedWords, final boolean isRtlLanguage) {
         clear();
-        mStripVisibilityGroup.setLayoutDirection(isRtlLanguage);
+        mPasteController.setLayoutDirection(isRtlLanguage);
         mSuggestedWords = suggestedWords;
         mStartIndexOfMoreSuggestions = mLayoutHelper.layoutAndReturnStartIndexOfMoreSuggestions(
                 getContext(), mSuggestedWords, mSuggestionsStrip, this);
-        mStripVisibilityGroup.showSuggestionsStrip();
+        mPasteController.onSuggestionsShown();
+    }
+
+    public static boolean canSuggestionsTakePriority(
+            final boolean suggestionCandidatesEnabled,
+            final boolean gestureFloatingPreviewTextEnabled,
+            final boolean shouldShowLxxSuggestionUi, final SuggestedWords suggestedWords) {
+        if (!suggestionCandidatesEnabled) {
+            return false;
+        }
+        // Count the same typed-word omission used by the strip layout. Punctuation and recorrection
+        // have input styles that keep every entry visible.
+        final boolean omitTypedWord = SuggestionStripLayoutHelper.shouldOmitTypedWord(
+                suggestedWords.mInputStyle, gestureFloatingPreviewTextEnabled,
+                shouldShowLxxSuggestionUi);
+        final int renderedSuggestionCount = suggestedWords.size() - (omitTypedWord ? 1 : 0);
+        return renderedSuggestionCount > 0;
+    }
+
+    public boolean updatePasteActionState(final boolean eligible,
+            final boolean suggestionsTakePriority) {
+        return mPasteController.updateState(eligible, suggestionsTakePriority);
+    }
+
+    public void closeTemporaryPasteMode() {
+        mPasteController.closeTemporaryMode();
+    }
+
+    public void resetPasteActionState() {
+        mPasteController.reset();
     }
 
     public void setMoreSuggestionsHeight(final int remainingHeight) {
@@ -229,7 +252,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
             dismissMoreSuggestionsPanel();
         }
         mLayoutHelper.layoutImportantNotice(mImportantNoticeStrip, importantNoticeTitle);
-        mStripVisibilityGroup.showImportantNoticeStrip();
+        mPasteController.showImportantNoticeStrip();
         mImportantNoticeStrip.setOnClickListener(this);
         return true;
     }
@@ -237,7 +260,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     public void clear() {
         mSuggestionsStrip.removeAllViews();
         removeAllDebugInfoViews();
-        mStripVisibilityGroup.showSuggestionsStrip();
+        mPasteController.showSuggestionsStrip();
         dismissMoreSuggestionsPanel();
     }
 
@@ -356,7 +379,7 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
 
     @Override
     public boolean onInterceptTouchEvent(final MotionEvent me) {
-        if (mStripVisibilityGroup.isShowingImportantNoticeStrip()) {
+        if (!mPasteController.isShowingSuggestionsStrip()) {
             return false;
         }
         // Detecting sliding up finger to show {@link MoreSuggestionsView}.
@@ -459,6 +482,9 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
                     false /* isKeyRepeat */);
             return;
         }
+        if (mPasteController.onClick(view)) {
+            return;
+        }
 
         final Object tag = view.getTag();
         // {@link Integer} tag is set at
@@ -475,9 +501,16 @@ public final class SuggestionStripView extends RelativeLayout implements OnClick
     }
 
     @Override
+    protected void onWindowVisibilityChanged(final int visibility) {
+        super.onWindowVisibilityChanged(visibility);
+        mPasteController.onWindowVisibilityChanged(visibility);
+    }
+
+    @Override
     protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
+        resetPasteActionState();
         dismissMoreSuggestionsPanel();
+        super.onDetachedFromWindow();
     }
 
     @Override


### PR DESCRIPTION
Some apps do not expose a toolbar Paste action compatible with secure paste. Apps built with Flutter are a common example: Flutter renders its own selection toolbar, and its Paste button asks the Flutter engine to read the clipboard directly instead of dispatching Android's standard editor Paste action. Without that trusted Paste event, secure paste blocks the read when the app is set to Paste only.

Add Paste to LatinIME so users can authorize the focused app directly from the keyboard. Preferably when this AOSP clipboard gets replaced in the future by another IME app, it should also implement paste actions.

Automatically offer a Paste chip for a clip set less than two minutes ago when the editor is empty or no candidates are visible. When candidates take priority or the clip is older, show a clipboard button that opens the chip on demand. The age limit is intentionally applied lazily without an expiry timer. Editing, receiving new candidates, changing focus, or closing the temporary mode returns the strip to its normal state. LatinIME never reads or displays clipboard contents. Password fields can therefore use the same generic Paste chip as other editors.

The chip dispatches Android's standard Paste action. The focused app reads and handles the clip, preserving generic Paste support for text, images, and other content. Remember only the platform timestamp for the last clip dispatched through the chip so the same clip is not repeatedly advertised across focus or process changes.

Enable the feature by default, provide a preference to disable it, and let editors opt out for individual fields.